### PR TITLE
add docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,9 @@ node_modules
 # Optional npm cache directory
 .npm
 
+# Application environment
+
+
 # Stored port data
 ports.json
 
@@ -24,3 +27,12 @@ ca.srl
 server.cert
 server.key
 server.csr
+
+
+
+Dockerfile
+LICENSE
+README.md
+.gitignore
+.dockerignore
+docker-compose.yml

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+LOGIN_PASSWORD = changeThisSecret-long-long-pa$$word!@#123!@#
+LISTEN_PORT = 4001

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:16.04
+
+WORKDIR /shadowsocks-restful-api
+
+COPY . .
+
+RUN apt-get update && apt-get install -y curl python-dev make g++ software-properties-common supervisor
+
+RUN set -ex && \
+    add-apt-repository ppa:max-c-lv/shadowsocks-libev -y && \
+    curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+    apt-get update && apt-get install nodejs shadowsocks-libev -y && \
+    npm i && \
+    mkdir -p /var/log/supervisor && \
+    cp supervisord.conf /etc/supervisor/conf.d/supervisord.conf && \
+    rm supervisord.conf && \
+    openssl req -x509 -sha256 -nodes -days 3365 \
+    -subj  "/C=CA/ST=QC/O=Company Inc/CN=example.com" \
+    -newkey rsa:2048 -keyout server.key \
+    -out server.cert
+
+
+RUN apt-get purge -y curl git software-properties-common && apt-get clean -y && apt-get autoclean -y && apt-get autoremove -y && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+
+CMD ["/usr/bin/supervisord"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,42 @@ A secure, reliable, standard restful api for managing shadowsocks-libev.
 
 A web app that manages users, server, nodes, products, accounts, and traffic can be found from [shadowsocks-hub](https://github.com/shadowsocks/shadowsocks-hub).
 
+## Install with Docker
+
+#### Install Docker and Compose plugin:
+```
+curl -fsSL https://get.docker.com -o get-docker.sh
+DRY_RUN=1 sudo sh ./get-docker.sh
+```
+
+#### Download shadowsocks-restful-api:
+```
+cd ~
+git clone https://github.com/shadowsocks/shadowsocks-restful-api.git
+```
+
+#### Change the login password of REST-api:
+```
+cd shadowsocks-restful-api/
+nano .env
+```
+* Note: LOGIN_PASSWORD in .env file, should be long and complex
+
+#### Build and run:
+```
+docker build -t shadow-rest:1.0.0 .
+docker compose up -d
+```
+
+#### Test it with LOGIN_PASSWORD to get jwt token:
+```
+curl -ik -H "Content-Type: application/json" -X POST -d '{"password":"changeThisSecret-long-long-pa$$word!@#123!@#"}' https://<public_ip_of_server>:4001/login
+```
+Response example:  
+```json
+{"token":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE1Mjk0ODg0MTcsImV4cCI6MTUyOTU3NDgxN30.9wdDV4hXvHdCkWhcOFpW2YXvSL6WupWSj2kTI6XMhFk"}
+```
+
 ## Install (Ubuntu 16.04)
 
 #### Download shadowsocks-restful-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.3'
+services:
+  shadow-rest:
+    restart: always
+    network_mode: host
+    container_name: shadow-rest
+    image: shadow-rest:1.0.0
+    volumes:
+      - shadow-configs:/root/.shadowsocks/
+
+volumes:
+  shadow-configs:

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,0 +1,16 @@
+[supervisord]
+nodaemon=true
+logfile=/dev/null
+logfile_maxbytes=0
+
+[program:node]
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+command=node app.js
+
+[program:shadowsocks]
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+command=ss-manager -u --manager-address /tmp/shadowsocks-manager.sock --fast-open


### PR DESCRIPTION
I have dockerized the node js rest-API and ss-server into one image that supervisord handles the two processes and also created a compose file.
If you kindly accept my pull request, I'll get the energy to create a Python cli for managing Shadowsocks accounts with the help of rest-API.